### PR TITLE
Stress test with 100k * 100KB

### DIFF
--- a/bridge-stress-test/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
+++ b/bridge-stress-test/src/test/scala/protocbridge/frontend/PosixPluginFrontendSpec.scala
@@ -6,6 +6,10 @@ import org.scalatest.matchers.must.Matchers
 import protocbridge.{ExtraEnv, ProtocCodeGenerator}
 
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeoutException
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 import scala.sys.process.ProcessIO
 import scala.util.Random
 
@@ -13,8 +17,8 @@ class PosixPluginFrontendSpec extends AnyFlatSpec with Matchers {
   if (!PluginFrontend.isWindows) {
     it must "execute a program that forwards input and output to given stream" in {
       val random = new Random()
-      val toSend = Array.fill(123)(random.nextInt(256).toByte)
-      val toReceive = Array.fill(456)(random.nextInt(256).toByte)
+      val toSend = Array.fill(100000)(random.nextInt(256).toByte)
+      val toReceive = Array.fill(100000)(random.nextInt(256).toByte)
       val env = new ExtraEnv(secondaryOutputDir = "tmp")
 
       val fakeGenerator = new ProtocCodeGenerator {
@@ -25,7 +29,7 @@ class PosixPluginFrontendSpec extends AnyFlatSpec with Matchers {
       }
 
       // Repeat 10,000 times since named pipes on macOS are flaky.
-      val repeatCount = 10000
+      val repeatCount = 100000
       for (i <- 1 to repeatCount) {
         if (i % 100 == 1) println(s"Running iteration $i of $repeatCount at ${java.time.LocalDateTime.now}")
 
@@ -42,9 +46,24 @@ class PosixPluginFrontendSpec extends AnyFlatSpec with Matchers {
           }, processOutput => {
             IOUtils.copy(processOutput, actualOutput)
             processOutput.close()
-          }, _.close()))
-        process.exitValue()
-        actualOutput.toByteArray mustBe toReceive
+          }, processError => {
+            IOUtils.copy(processError, System.err)
+            processError.close()
+          }))
+        try {
+          Await.result(Future { process.exitValue() }, 15.seconds)
+        } catch {
+          case _: TimeoutException =>
+            System.err.println(s"Timeout on iteration $i of $repeatCount ($state)")
+            process.destroy()
+        }
+        val response = actualOutput.toByteArray
+        if (!(response sameElements toReceive)) {
+          System.err.println(
+            s"Mismatch on iteration $i of $repeatCount: " +
+              s"response(${response.length}) != toReceive(${toReceive.length}) ($state)"
+          )
+        }
         PosixPluginFrontend.cleanup(state)
       }
     }


### PR DESCRIPTION
```
sbt "project bridgeStressTest" "testOnly protocbridge.frontend.PosixPluginFrontendSpec"

Running iteration 1 of 100000 at 2024-10-10T09:18:53.933490
Timeout on iteration 2355 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-11130744604771524491/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-11130744604771524491/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-11130744604771524491,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge10557587628126456987))
Timeout on iteration 37967 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-8506626143154882308/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-8506626143154882308/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-8506626143154882308,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge14640564632372802208))
Timeout on iteration 52391 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-4895308378860929768/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-4895308378860929768/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-4895308378860929768,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge5447388782906696104))
Timeout on iteration 59530 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10747571322634158266/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10747571322634158266/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10747571322634158266,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge13321332024476404867))
Timeout on iteration 63572 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-2247161286772765240/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-2247161286772765240/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-2247161286772765240,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge4152677730892863678))
Timeout on iteration 65882 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10597085216251008019/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10597085216251008019/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-10597085216251008019,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge1708870770218670334))
Timeout on iteration 66456 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-12814957716865245595/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-12814957716865245595/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-12814957716865245595,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge4831689774403947755))
Timeout on iteration 99002 of 100000 (InternalState(/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-14985364797726431130/input,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-14985364797726431130/output,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protopipe-14985364797726431130,/var/folders/jc/tqbm_w_s0ds_mxg9dvsg6q3w0000gp/T/protocbridge5390092884456608607))
Running iteration 99901 of 100000 at 2024-10-10T10:28:27.363372
```